### PR TITLE
Handling End of Route Seg Fault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 project(FrenetOptimalTrajectory)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/FrenetOptimalTrajectory/fot_wrapper.py
+++ b/FrenetOptimalTrajectory/fot_wrapper.py
@@ -8,7 +8,7 @@ try:
     cdll = ctypes.CDLL("build/libFrenetOptimalTrajectory.so")
 except:
     cdll = ctypes.CDLL(
-        "{}/pylot/planning/frenet_optimal_trajectory/frenet-optimal-trajectory-planner/"
+        "{}/pylot/planning/frenet_optimal_trajectory/frenet_optimal_trajectory_planner/"
         "build/libFrenetOptimalTrajectory.so".format(os.getcwd())
     )
 

--- a/src/FrenetOptimalTrajectory/FrenetOptimalTrajectory.cpp
+++ b/src/FrenetOptimalTrajectory/FrenetOptimalTrajectory.cpp
@@ -17,6 +17,15 @@ FrenetOptimalTrajectory::FrenetOptimalTrajectory(vector<double>& x_,
         vector<tuple<double, double>>& obstacles_):
         x(x_), y(y_), s0(s0_), c_speed(c_speed_), c_d(c_d_), c_d_d(c_d_d_),
         c_d_dd(c_d_dd_), target_speed(target_speed_), obstacles(obstacles_) {
+    // make sure best_frenet_path is initialized
+    best_frenet_path = nullptr;
+
+    // exit if not enough waypoints
+    if (x.size() <= 2) {
+        return;
+    }
+
+    // construct spline path
     csp = new CubicSpline2D(x, y);
 
     // calculate the trajectories

--- a/src/FrenetOptimalTrajectory/fot_wrapper.cpp
+++ b/src/FrenetOptimalTrajectory/fot_wrapper.cpp
@@ -48,7 +48,7 @@ extern "C" {
         FrenetPath* best_frenet_path = fot.getBestPath();
 
         int success = 0;
-        if (!best_frenet_path->x.empty()){
+        if (best_frenet_path && !best_frenet_path->x.empty()){
             int last = 0;
             for (int i = 0; i < best_frenet_path->x.size(); i++) {
                 x_path[i] = best_frenet_path->x[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,10 @@ int main() {
     for (int i = 0; i < 40; i++) {
         FrenetOptimalTrajectory fot = FrenetOptimalTrajectory(wx, wy, s0, c_speed, c_d, c_d_d, c_d_dd, 10, obstacles);
         FrenetPath* best_frenet_path = fot.getBestPath();
+        if (!best_frenet_path) {
+            print("Failed to find frenet optimal trajecotry.")
+            continue;
+        }
         s0 = best_frenet_path->s[1];
         c_d = best_frenet_path->d[1];
         c_d_d = best_frenet_path->d_d[1];


### PR DESCRIPTION
If there's only 1 point left in the waypoint list, the planner will segfault as it relies on differencing to calculate the Cubic Spline. Thus PR handles that error to just stop at the final waypoint. This also changes the minimum required cmake version.